### PR TITLE
fix(makefile): guard release target against pre-existing tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,8 @@ upgrade:
 #release: @ Create and push a new tag
 release:
 	$(eval NT=$(NEWTAG))
+	@if git rev-parse -q --verify "refs/tags/${NT}" >/dev/null 2>&1; then echo "ERROR: tag ${NT} already exists locally. Pick a new version or delete it: git tag -d ${NT}"; exit 1; fi
+	@if git ls-remote --exit-code --tags origin "refs/tags/${NT}" >/dev/null 2>&1; then echo "ERROR: tag ${NT} already exists on origin. Pick a new version."; exit 1; fi
 	@echo -n "Are you sure to create and push ${NT} tag? [y/N] " && read ans && [ $${ans:-N} = y ]
 	@echo ${NT} > ./version.txt
 	@git add -A


### PR DESCRIPTION
Adds local + remote `git` tag pre-existence checks to the `release` recipe before any mutation (version.txt write, `git add`/`commit`) and before the confirm prompt.

**Bug:** the recipe wrote `version.txt`, committed, then ran `git tag` with no existence check. Re-running with an already-used tag landed a dangling "Cut vX release" commit while `git tag` aborted — a half-published release.

Implements Safety Check #16 from the `/makefile` skill.

Verified: `make -n release` parses; `make release NEWTAG=v0.0.1` (an existing tag) errors at the guard before any commit, leaving the tree and tags untouched.